### PR TITLE
Add support for custom matchers

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -11,6 +11,7 @@ indent() {
 }
 
 describe() {
+  subject=$1
   indent
   echo "$1"
   ((test_indent += 2))
@@ -26,6 +27,15 @@ end_describe() {
 it() {
   ((examples += 1))
   assertion="$1"
+}
+
+should() {
+  title="should $@"
+  it "$title"
+  matcher="$1"
+  shift
+  args="$@"
+  $matcher "$subject" "$args"
 }
 
 assert() {

--- a/shpec/matchers/process.sh
+++ b/shpec/matchers/process.sh
@@ -1,0 +1,10 @@
+have_process_count() {
+  pattern=`echo $1 | sed 's/\(.\)/[\1]/'`
+  expected_count=$2
+  process_list=`ps waux|grep "[0-9][0-9] $pattern"`
+  echo "$process_list" |
+    sed 's/^/      /g' |
+    sed 's/[ ]*$//g'  # for ?some? reason unicorn jobs have a bunch of ugly trailing whitespace
+  process_count=`[[ -z $process_list ]] && echo 0 || echo "$process_list"|wc -l`
+  assert equal $process_count $expected_count
+}

--- a/shpec/matchers/unicorn.sh
+++ b/shpec/matchers/unicorn.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env shpec
+. process.sh
+
+describe "unicorn_rails worker"
+  it
+    should have_process_count 8
+end_describe


### PR DESCRIPTION
eg.
#### process.sh

``` sh
have_process_count() {
  pattern=`echo $1 | sed 's/\(.\)/[\1]/'`
  expected_count=$2
  process_list=`ps waux|grep "[0-9][0-9] $pattern"`
  echo "$process_list" |
    sed 's/^/      /g' |
    sed 's/[ ]*$//g'  # for ?some? reason unicorn jobs have a bunch of ugly trailing whitespace
  process_count=`[[ -z $process_list ]] && echo 0 || echo "$process_list"|wc -l`
  assert equal $process_count $expected_count
}
```
#### unicorn.sh

``` sh
#!/usr/bin/env shpec
. process.sh

describe "unicorn_rails worker"
  it
    should have_process_count 8
end_describe
```
