### PR TITLE
Remove sudo from installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,6 @@ SHPECDIR=${TMPDIR}/shpec-${VERSION}
 cd $TMPDIR
 curl -sL https://github.com/shpec/shpec/archive/${VERSION}.tar.gz | tar zxf -
 cd $SHPECDIR
-sudo make install
+make install
 cd $TMPDIR
 rm -rf $SHPECDIR


### PR DESCRIPTION
@locochris do you need to use `sudo` when doing `make install` on your machine? It works fine on my mac without the `sudo`.
