### PR TITLE
Gt lt bugfix

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -49,10 +49,10 @@ assert() {
     print_result "[[ $'$2' != $'$3' ]]" "Expected [$2] not to equal [$3]";;
 
   xgt )
-    print_result "[[ '$2' > '$3' ]]" "Expected [$2] to be > [$3]";;
+    print_result "[[ $2 -gt $3 ]]" "Expected [$2] to be > [$3]";;
 
   xlt )
-    print_result "[[ '$2' < '$3' ]]" "Expected [$2] to be < [$3]";;
+    print_result "[[ $2 -lt $3 ]]" "Expected [$2] to be < [$3]";;
 
   xmatch )
     print_result "[[ '$2' =~ $3 ]]" "Expected [$2] to match [$3]";;

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -30,6 +30,16 @@ line'
       assert equal "$multiline_string" "$string_with_newline_char"
   end_describe
 
+  describe "lt matcher"
+    it "handles numbers of different length properly"
+      assert lt 5 17
+  end_describe
+
+  describe "gt matcher"
+    it "handles numbers of different length properly"
+      assert gt 17 5
+  end_describe
+
   describe "passing through to the test builtin"
     it "asserts an arbitrary algebraic test"
       assert test "[[ 5 -lt 10 ]]"


### PR DESCRIPTION
Was giving failures for eg.

```
[[ "5" < "17" ]]
```

Where the fix was to use:

```
[[ "5" -lt "17" ]]
```
