### PR TITLE
Add default TMPDIR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -ex
 VERSION=0.0.6
+
+TMPDIR=${TMPDIR:-/tmp}
+
 SHPECDIR=${TMPDIR}/shpec-${VERSION}
 
 cd $TMPDIR


### PR DESCRIPTION
For installing on environments where TMPDIR isn't set.

(eg. Ubuntu)
