### PR TITLE
Pass in SHPEC_ROOT as an env variable

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -96,8 +96,8 @@ print_result() {
   fi
 }
 
-shpec_root="$(find . -name 'shpec' -type d | grep -v '.git')"
-shpec_root="${shpec_root:-.}" # default to current directory
+shpec_root=${SHPEC_ROOT:-$(find . -name 'shpec' -type d | grep -v '.git')}
+shpec_root=${shpec_root:-.} # default to current directory
 
 case "$1" in
 


### PR DESCRIPTION
Setting this will allow shpec to avoid recursively trying to find the
"shpec_root" starting in the current dir.

eg. 
  https://github.com/locochris/syscheck/blob/master/bin/syscheck

Actually passes itself in as a shpec to `shpec` to run its own shpecs, so it doesn't need to go looking for a "shpec_root".

``` bash
#!/usr/bin/env SHPEC_ROOT=. shpec
...
describe ...
```

The above script works fine, but because there is no way to tell `shpec` not to, it recursively tries to find the "shpec_root" starting in the current dir.  (And if run from some directories - eg. `$HOME` for me, this can take a _very_ _long_ time).
