### PR TITLE
Add it blocks

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -33,7 +33,13 @@ unstub_command() { unset -f "$1"; }
 
 it() {
   ((examples += 1))
-  assertion="$1"
+  if [[ $* ]]; then
+    assertion=$*
+  else
+    block=$(cat </dev/stdin | sed 's/^[ ]*//g')
+    assertion=$block
+    eval $block
+  fi
 }
 
 assert() {

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -78,6 +78,12 @@ line'
       assert custom_assertion "argument"
   end_describe
 
+  describe "it blocks"
+    it <<-'EOF'
+      assert equal $((1+1)) 2
+EOF
+  end_describe
+
   describe "exit codes"
     shpec_cmd="$shpec_root/../bin/shpec"
     it "returns nonzero if any test fails"


### PR DESCRIPTION
Don't know if anyone will think this sugar is sweet enough, but ...

Instead of writing:

``` bash
it "assert equal $((1+1)) 2"
  assert equals $((1+1)) 2
```

write:

``` bash
it <<-'EOF'
  assert equal $((1+1)) 2
EOF
```
