### PR TITLE
Make it POSIX

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -111,8 +111,8 @@ print_result() {
     iecho "$green$assertion$norm"
   else
     ((failures += 1))
-    iecho -e "$red$assertion"
-    iecho -e "($2)$norm"
+    iecho "$red$assertion"
+    iecho "($2)$norm"
   fi
 }
 

--- a/bin/shpec
+++ b/bin/shpec
@@ -2,7 +2,7 @@
 : Use one of: bash, dash, or ksh93
 
 indent() {
-  printf '%*s' $(((test_indent - 1) * 2))
+  printf '%*s' $(( (test_indent - 1) * 2))
 }
 
 # 'echo -e' is not a POSIX feature.

--- a/bin/shpec
+++ b/bin/shpec
@@ -1,16 +1,28 @@
+#
 : Use one of: bash, dash, or ksh93
-
 
 indent() {
   printf '%*s' $(((test_indent - 1) * 2))
 }
 
+# 'echo -e' is not a POSIX feature.
+# This helps us to work around that.
+echo_needs_minus_e(){
+  echo "\010"| (read a; [ ${#a} -ne 1 ])
+}
+
+if echo_needs_minus_e; then
+  echoe() { echo -e "$@"; }
+else
+  echoe() { echo "$@"; }
+fi
+
 iecho() {
-  indent && echo "$@"
+  indent && echoe "$@"
 }
 
 sanitize() {
-  IFS= echo -e "$1" | tr '\n' 'n' | tr "'" 'q'
+  IFS= echoe "$1" | tr '\n' 'n' | tr "'" 'q'
 }
 
 describe() {
@@ -96,7 +108,7 @@ assert() {
 
 print_result() {
   if eval "$1"; then
-    iecho -e "$green$assertion$norm"
+    iecho "$green$assertion$norm"
   else
     ((failures += 1))
     iecho -e "$red$assertion"

--- a/bin/shpec
+++ b/bin/shpec
@@ -61,52 +61,64 @@ it() {
 
 assert() {
   case "x$1" in
-
   xequal )
-    print_result "[[ '$(sanitize "$2")' = '$(sanitize "$3")' ]]" "Expected [$2] to equal [$3]";;
-
+    print_result "[ '$(sanitize "$2")' = '$(sanitize "$3")' ]" \
+      "Expected [$2] to equal [$3]"
+  ;;
   xunequal )
-    print_result "[[ '$(sanitize "$2")' != '$(sanitize "$3")' ]]" "Expected [$2] not to equal [$3]";;
-
+    print_result "[ '$(sanitize "$2")' != '$(sanitize "$3")' ]" \
+      "Expected [$2] not to equal [$3]"
+  ;;
   xgt )
-    print_result "[[ $2 -gt $3 ]]" "Expected [$2] to be > [$3]";;
-
+    print_result "[ $2 -gt $3 ]" \
+      "Expected [$2] to be > [$3]"
+  ;;
   xlt )
-    print_result "[[ $2 -lt $3 ]]" "Expected [$2] to be < [$3]";;
-
+    print_result "[ $2 -lt $3 ]" \
+      "Expected [$2] to be < [$3]"
+  ;;
   xmatch )
-    print_result "[[ '$2' =~ $3 ]]" "Expected [$2] to match [$3]";;
-
+    print_result "case '$2' in *$3*) :;; *) false;; esac" \
+      "Expected [$2] to match [$3]"
+  ;;
   xno_match )
-    print_result "[[ ! '$2' =~ $3 ]]" "Expected [$2] not to match [$3]";;
-
+    print_result "case '$2' in *$3*) false ;; *) :;; esac" \
+      "Expected [$2] not to match [$3]"
+  ;;
   xpresent )
-    print_result "[[ -n '$2' ]]" "Expected [$2] to be present";;
-
+    print_result "[ -n '$2' ]" \
+      "Expected [$2] to be present"
+  ;;
   xblank )
-    print_result "[[ -z '$2' ]]" "Expected [$2] to be blank";;
+    print_result "[ -z '$2' ]" \
+      "Expected [$2] to be blank"
+  ;;
 
   xfile_present )
-    print_result "[[ -e $2 ]]" "Expected file [$2] to exist";;
-
+    print_result "[ -e $2 ]" \
+      "Expected file [$2] to exist"
+  ;;
   xfile_absent )
-    print_result "[[ ! -e $2 ]]" "Expected file [$2] not to exist";;
-
+    print_result "[ ! -e $2 ]" \
+      "Expected file [$2] not to exist"
+  ;;
   xsymlink )
     link="$(readlink $2)"
-    print_result "[[ '$link' = '$3' ]]" "Expected [$2] to link to [$3], but got [$link]";;
-
+    print_result "[ '$link' = '$3' ]" \
+      "Expected [$2] to link to [$3], but got [$link]"
+  ;;
   xtest )
-    print_result "$2" "Expected $2 to be true";;
-
+    print_result "$2" \
+      "Expected $2 to be true"
+  ;;
   * )
     if type "$1" 2>/dev/null | grep -q 'function'; then
       matcher="$1"; shift
       $matcher "$@"
     else
       print_result false "Error: Unknown matcher [$1]"
-    fi;;
-
+    fi
+  ;;
   esac
 }
 
@@ -131,7 +143,7 @@ shpec() {
   green="\033[0;32m"
   norm="\033[0m"
 
-  SHPEC_ROOT=${SHPEC_ROOT:-$([[ -d './shpec' ]] && echo './shpec' || echo '.')}
+  SHPEC_ROOT=${SHPEC_ROOT:-$([ -d './shpec' ] && echo './shpec' || echo '.')}
   case "$1" in
   ( -v | --version ) echo "$VERSION"
   ;;

--- a/bin/shpec
+++ b/bin/shpec
@@ -38,9 +38,13 @@ end() {
 }
 
 end_describe() {
-  iecho "Warning: end_describe will be deprecated in shpec 1.0. Please use end instead."
+  iecho "Warning: end_describe will be deprecated in shpec 1.0." \
+    "Please use end instead."
   end
 }
+
+# Beware: POSIX shells are not required to accept
+# any identifier as a function name.
 
 stub_command() {
   body="${2:-:}"

--- a/bin/shpec
+++ b/bin/shpec
@@ -1,11 +1,5 @@
-#!/usr/bin/env bash
-VERSION=0.1.2
-examples=0
-failures=0
-test_indent=0
-red="\033[0;31m"
-green="\033[0;32m"
-norm="\033[0m"
+: Use one of: bash, dash, or ksh93
+
 
 indent() {
   printf '%*s' $(((test_indent - 1) * 2))
@@ -110,31 +104,60 @@ print_result() {
   fi
 }
 
-SHPEC_ROOT=${SHPEC_ROOT:-$([[ -d './shpec' ]] && echo './shpec' || echo '.')}
 
-case "$1" in
+shpec() {
+  (
+  VERSION=0.1.2posix
+  examples=0
+  failures=0
+  test_indent=0
+  red="\033[0;31m"
+  green="\033[0;32m"
+  norm="\033[0m"
 
-  -v|--version )
+  SHPEC_ROOT=${SHPEC_ROOT:-$([[ -d './shpec' ]] && echo './shpec' || echo '.')}
+  case "$1" in
+  ( -v | --version ) echo "$VERSION"
+  ;;
+  ( * )
+      matcher_files="$(
+          find "$SHPEC_ROOT/matchers" -name '*.sh' 2>/dev/null
+      )"
 
-    echo "$VERSION";;
+      for matcher_file in $matcher_files; do
+        . "$matcher_file"
+      done
 
-  * )
+      if [ $# -gt 0 ] ; then
+        : \$1="'$1'" \${#1}="'${#1}'"
+        files="${@}"
+      else
+        files=$(
+          find $SHPEC_ROOT -name '*_shpec.sh'
+        )
+      fi
 
-    matcher_files="$(find "$SHPEC_ROOT/matchers" -name '*.sh' 2>/dev/null)"
+      for file in $files; do
+        echo >& 2 "$file"
+        . "$file" || exit
+      done
 
-    for matcher_file in $matcher_files; do
-      . "$matcher_file"
-    done
+      [ $failures -eq 0 ] && color=$green || color=$red
+      echo -e "${color}${examples} examples, ${failures} failures${norm}"
 
-    files="${@:-$(find $SHPEC_ROOT -name '*_shpec.sh')}"
+      times
+      [ $failures -eq 0 ]
+      exit
+  ;;
+  esac
+  )
+}
 
-    time for file in $files; do
-      . "$file"
-    done
+(
+  _progname=shpec
+  _pathname=$( command -v $0 )
+  _cmdname=${_pathname##*/}
+  _main=shpec
 
-    [ $failures -eq 0 ] && color=$green || color=$red
-    echo -e "${color}${examples} examples, ${failures} failures${norm}"
-
-    [ $failures -eq 0 ]
-
-esac
+  case $_progname in (${_cmdname%.sh}) $_main "$@";; esac
+)

--- a/bin/shpec
+++ b/bin/shpec
@@ -26,12 +26,12 @@ sanitize() {
 }
 
 describe() {
-  ((test_indent += 1))
+  : $((test_indent += 1))
   iecho "$1"
 }
 
 end() {
-  ((test_indent -= 1))
+  : $((test_indent -=1 ))
   if [ $test_indent -eq 0 ]; then
     [ $failures -eq 0 ]
   fi
@@ -50,8 +50,8 @@ stub_command() {
 unstub_command() { unset -f "$1"; }
 
 it() {
-  ((test_indent += 1))
-  ((examples += 1))
+  : $((test_indent += 1))
+  : $((examples += 1))
   assertion="$1"
 }
 
@@ -110,7 +110,7 @@ print_result() {
   if eval "$1"; then
     iecho "$green$assertion$norm"
   else
-    ((failures += 1))
+    : $((failures += 1))
     iecho "$red$assertion"
     iecho "($2)$norm"
   fi

--- a/bin/shpec
+++ b/bin/shpec
@@ -171,7 +171,7 @@ shpec() {
       done
 
       [ $failures -eq 0 ] && color=$green || color=$red
-      echo -e "${color}${examples} examples, ${failures} failures${norm}"
+      echoe "${color}${examples} examples, ${failures} failures${norm}"
 
       times
       [ $failures -eq 0 ]

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -69,11 +69,20 @@ line'
   end
 
   describe "stubbing commands"
+    # only bash lets us redefine 'exit', so use 'false'
+    it "check original working of the stub"
+      false
+      assert equal "$?" 1
+    end
     it "stubs to the null command by default"
-      stub_command "exit"
-      exit # doesn't really exit
+      stub_command "false"
+      false # doesn't do anything
       assert equal "$?" 0
-      unstub_command "exit"
+      unstub_command "false"
+    end
+    it "preserves the original working of the stub"
+      false
+      assert equal "$?" 1
     end
 
     it "accepts an optional function body"

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -64,7 +64,7 @@ line'
 
   describe "passing through to the test builtin"
     it "asserts an arbitrary algebraic test"
-      assert test "[[ 5 -lt 10 ]]"
+      assert test "[ 5 -lt 10 ]"
     end
   end
 

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -35,7 +35,8 @@ describe "shpec"
 
   describe "equality matcher"
     it "handles newlines properly"
-      string_with_newline_char="new\nline"
+      string_with_newline_char="new
+line"
       multiline_string='new
 line'
       assert equal "$multiline_string" "$string_with_newline_char"
@@ -117,14 +118,13 @@ line'
   end
 
   describe "exit codes"
-    shpec_cmd="$SHPEC_ROOT/../bin/shpec"
     it "returns nonzero if any test fails"
-      $shpec_cmd $SHPEC_ROOT/etc/failing_example &> /dev/null
+      shpec $SHPEC_ROOT/etc/failing_example > /dev/null 2>& 1
       assert unequal "$?" "0"
     end
 
     it "returns zero if a suite passes"
-      $shpec_cmd $SHPEC_ROOT/etc/passing_example &> /dev/null
+      shpec $SHPEC_ROOT/etc/passing_example > /dev/null 2>& 1
       assert equal "$?" "0"
     end
   end
@@ -142,18 +142,17 @@ line'
   end
 
   describe "commandline options"
-    shpec_cmd="$SHPEC_ROOT/../bin/shpec"
 
     describe "--version"
       it "outputs the current version number"
-        message="$($shpec_cmd --version)"
+        message="$(shpec --version)"
         assert match "$message" "$(cat $SHPEC_ROOT/../VERSION)"
       end
     end
 
     describe "-v"
       it "outputs the current version number"
-        message="$($shpec_cmd -v)"
+        message="$(shpec -v)"
         assert match "$message" "$(cat $SHPEC_ROOT/../VERSION)"
       end
     end


### PR DESCRIPTION
Two major updates:

This removes any '...shisms' not compatible with POSIX.  We're not going back to pure Bourne shell, which I consider too primitive.  See the individual deltas for what changed.  Two major things were:

* Arithmetic notation, which I fixed with a hack: prefix every `(( ... ))` expression with `: $`.

* Simple, single bracket tests:  `[ ... ]` instead of `[[ ... ]]`

The second change is to throw all code into functions, this makes testing of functions simple, as we can just source the shpec script and test functions separately.  It also simplifies recursive calls to 
shpec. However, recursive calls do not update the assertion and failure counters, as its internals
run in a subshell, to protect the environment.

Performance: I had a simple set of 37 assertions which run in ~12 ms on my laptop.
There's little difference between bash, ksh and dash, except that bash takes an extra 8-10 ms to start itself.

I'm still looking for the shell equivalent of python's `if __name__ == '__main__':`
Until then I need to trigger on the value of `$0`.


   
