### PR TITLE
Simplify echoe() using printf

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -4,17 +4,7 @@ indent() {
   printf '%*s' $(( (test_indent - 1) * 2))
 }
 
-# 'echo -e' is not a POSIX feature.
-# This helps us to work around that.
-echo_needs_minus_e(){
-  echo "\010"| (read a; [ ${#a} -ne 1 ])
-}
-
-if echo_needs_minus_e; then
-  echoe() { echo -e "$@"; }
-else
-  echoe() { echo "$@"; }
-fi
+echoe() { printf "%b\n" "$*"; }
 
 iecho() {
   indent && echoe "$@"


### PR DESCRIPTION
Replace the helper functions with a one-line definition of `echoe()`