### PR TITLE
Stop checking status of a shpec file

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -21,9 +21,9 @@ describe() {
 
 end() {
   : $((test_indent -= 1))
-  if [ $test_indent -eq 0 ]; then
-    [ $failures -eq 0 ]
-  fi
+  [ $test_indent -lt 0 ] || return 0
+  printf >& 2 "shpec: $_shpec_file: syntax error\n"
+  exit 1
 }
 
 end_describe() {
@@ -175,8 +175,8 @@ shpec() {
       )
     fi
 
-    for file in $files; do
-      . "$file"
+    for _shpec_file in $files; do
+      . "$_shpec_file"
     done
 
     final_results

--- a/bin/shpec
+++ b/bin/shpec
@@ -22,7 +22,7 @@ describe() {
 end() {
   : $((test_indent -= 1))
   [ $test_indent -lt 0 ] || return 0
-  printf >& 2 "shpec: $_shpec_file: syntax error\n"
+  echo >& 2 "shpec: $_shpec_file: unexpected 'end'"
   exit 1
 }
 

--- a/shpec/etc/syntax_error
+++ b/shpec/etc/syntax_error
@@ -1,0 +1,3 @@
+describe "a malformed file"
+end
+end

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -136,6 +136,20 @@ line'
     end
   end
 
+  describe "malformed test files"
+    _f=$SHPEC_ROOT/etc/syntax_error
+    it "exits with an error"
+      shpec $_f > /dev/null 2>& 1
+      assert unequal "$?" "0"
+    end
+
+    it "informs you of the malformed shpec test file"
+      shpec $_f > /tmp/syntax_error_output 2>& 1
+      message="$(cat /tmp/syntax_error_output)"
+      assert match "$message" "$_f"
+    end
+  end
+
   describe "commandline options"
 
     describe "--version"


### PR DESCRIPTION
We ignore the check on the failures counter, as it's result
was never checked anywhere.

Instead, we check for the indent level going below 0,
and bail out if it does.

There is a slightly different version with  `>& 2` at the end of the line, as branch issue#65b

I prefer this one, where the redirection is next to the `printf` 