### PR TITLE
Fix for #65

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -21,9 +21,9 @@ describe() {
 
 end() {
   : $((test_indent -= 1))
-  if [ $test_indent -eq 0 ]; then
-    [ $failures -eq 0 ]
-  fi
+  [ $test_indent -lt 0 ] || return 0
+  printf "shpec: $_shpec_file: syntax error\n" >& 2
+  exit 1
 }
 
 end_describe() {
@@ -175,8 +175,8 @@ shpec() {
       )
     fi
 
-    for file in $files; do
-      . "$file"
+    for _shpec_file in $files; do
+      . "$_shpec_file"
     done
 
     final_results


### PR DESCRIPTION
We ignore the check on the failures counter, as it's result
was never checked anywhere.

Instead, we check for the indent level going below 0,
and bail out if it does.

This has the more conventional `>& 2` at the end of the line.