### PR TITLE
Make installing `shellcheck` more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   allow_failures:
     - env: SHELL=zsh
 script:
-  - >
+  - |
     if ${LINT:-false}; then
       shellcheck -s sh bin/shpec  # Just use th `sh` dialect
     else
@@ -19,11 +19,16 @@ script:
     fi
 cache: apt
 before_install:
-  - >
+  - |
     if ${LINT:-false}; then
-      SHELLCHECK_PKG=shellcheck_0.3.5-2_amd64.deb
-      wget http://ftp.debian.org/debian/pool/main/s/shellcheck/$SHELLCHECK_PKG
-      sudo dpkg -i $SHELLCHECK_PKG
+      latest_versions="0.3.5-3 0.3.4-3"
+      for v in $latest_versions; do
+        pkg=shellcheck_${v}_amd64.deb
+        url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
+        wget $url/$pkg || continue
+        echo $version $v && break
+      done
+      sudo dpkg -i $pkg
     else
       if ! type $SHELL > /dev/null; then
         sudo apt-get update -qq &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,20 @@ script:
 cache: apt
 before_install:
   - |
-    if ${LINT:-false}; then
-      latest_versions="0.3.5-3 0.3.4-3"
-      for v in $latest_versions; do
+    get_shellcheck() {
+      for v 
+      do
         pkg=shellcheck_${v}_amd64.deb
         url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
         wget $url/$pkg || continue
-        echo $version $v && break
+        echo $pkg 
       done
-      sudo dpkg -i $pkg
-    else
-      if ! type $SHELL > /dev/null; then
+    }
+    if ${LINT:-false}; then
+      pkg=$( get_shellcheck 0.3.5-3 0.3.4-3 )
+      exec sudo dpkg -i $pkg
+    fi
+    if ! type $SHELL > /dev/null; then
         sudo apt-get update -qq &&
         sudo apt-get install -y $SHELL
-      fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,29 +12,30 @@ matrix:
     - env: SHELL=zsh
 script:
   - |
-    ${LINT:-false} &&
-      exec shellcheck -s sh bin/shpec  # `sh` refers to POSIX
-    $SHELL bin/shpec shpec/shpec_shpec.sh
+    if ${LINT:-false}; then
+      shellcheck -s sh bin/shpec  # 'sh' refers to POSIX
+    else
+      $SHELL bin/shpec shpec/shpec_shpec.sh
+    fi
 cache: apt
 before_install:
   - |
     get_shellcheck() {
       (
-      for v 
+      for v
       do
         pkg=shellcheck_${v}_amd64.deb
         url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
         wget $url/$pkg || continue
-        echo $pkg 
+        echo $pkg
         break
       done
       )
     }
     if ${LINT:-false}; then
       pkg=$( get_shellcheck 0.3.5-3 0.3.4-3 )
-      exec sudo dpkg -i $pkg
-    fi
-    if ! type $SHELL > /dev/null; then
+      sudo dpkg -i $pkg
+    elif ! type $SHELL > /dev/null; then
         sudo apt-get update -qq &&
         sudo apt-get install -y $SHELL
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache: apt
 before_install:
   - |
     get_shellcheck() {
+      (
       for v 
       do
         pkg=shellcheck_${v}_amd64.deb
@@ -27,6 +28,7 @@ before_install:
         echo $pkg 
         break
       done
+      )
     }
     if ${LINT:-false}; then
       pkg=$( get_shellcheck 0.3.5-3 0.3.4-3 )

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
         url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
         wget $url/$pkg || continue
         echo $pkg 
+        break
       done
     }
     if ${LINT:-false}; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,9 @@ matrix:
     - env: SHELL=zsh
 script:
   - |
-    if ${LINT:-false}; then
-      shellcheck -s sh bin/shpec  # Just use th `sh` dialect
-    else
-      time $SHELL bin/shpec shpec/shpec_shpec.sh
-    fi
+    ${LINT:-false} &&
+      exec shellcheck -s sh bin/shpec  # `sh` refers to POSIX
+    $SHELL bin/shpec shpec/shpec_shpec.sh
 cache: apt
 before_install:
   - |


### PR DESCRIPTION

Core functional change here is that we allow travis to fallback on a known, existing version in the debian `shellcheck` repository.

So now we work with a list of known versions of shellcheck, and a function `get_shellcheck` that
will download the first valid match and report the proper package name.

If no valid package can be downloaded, package name will be empty, and the install will abort.

-- 
Cosmetic changes:

* Switch from Folding `>` to Literal `|`  for multi-line shell chunks.  I would expect folding to generate shell syntax errors, but I haven't seen any.  Does travis interpret this yaml correctly?

* Explain why we use shellcheck `-s sh`.  It's the POSIX way.
