### PR TITLE
Move internal variables to _shpec_ namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ shpec [![Build Status](https://travis-ci.org/rylnd/shpec.png)](https://travis-ci
 *Test your shell scripts!*
 
 <p align='center'>
-  <img src='https://raw.github.com/wiki/rylnd/shpec/images/screenshot.png' alt="Screenshot of shpec" />
+  <img src='https://raw.github.com/wiki/rylnd/shpec/images/screenshot.png' 
+       alt="Screenshot of shpec" />
 </p>
 
 ## Using shpec
@@ -34,9 +35,11 @@ https://github.com/rspec/rspec), [`Jasmine`](
 https://github.com/jasmine/jasmine), and [`mocha`](
 https://github.com/mochajs/mocha).
 
-The two main constructs are `describe/end` (used to group tests) and `it/end` (used to describe an individual test and wrap assertions).
+The two main constructs are `describe/end` (used to group tests) and `it/end`
+(used to describe an individual test and wrap assertions).
 
-__Note:__ Since your test files will be sourced into `shpec`, you can use any shell command that would normally be available in your session.
+__Note:__ Since your test files will be sourced into `shpec`, you can use any
+shell command that would normally be available in your session.
 
 ### Examples
 [shpec's own tests](
@@ -97,7 +100,8 @@ end
 
 ### Stubbing
 You can stub commands using `stub_command`.
-This function takes the name of the command you wish to stub. If provided, the second argument will be used as the body of the command. (code that would be evaluated)
+This function takes the name of the command you wish to stub. If provided,
+the second argument will be used as the body of the command. (code that would be evaluated)
 Once you're done, you can delete it with `unstub_command`.
 
 The best example is the [shpec test for this feature](
@@ -124,11 +128,11 @@ any POSIX compliant shell.  You can use `shpec` to test scripts
 that use non-POSIX features, but you must avoid them when extending
 `shpec` or the main `shpec_shpech.sh` tests.
 
-Any variables starting with the `_shpec_` prefix are reserved
-for internal use and should not be used in test cases (except
-perhaps for test cases of `shpec` itself).
+Namespace
 
-
+Any variables starting with `_shpec_` are reserved for internal use and
+should not be used in test cases (except perhaps for test cases of `shpec`
+itself).
 
 If you've got a test or custom matcher you're particularly proud of,
 please consider adding it to [the Examples page](

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-shpec [![Build Status](https://travis-ci.org/rylnd/shpec.png)](https://travis-ci.org/rylnd/shpec) [![Join the chat at https://gitter.im/rylnd/shpec](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/rylnd/shpec?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+shpec [![Build Status](
+https://travis-ci.org/rylnd/shpec.png)](
+https://travis-ci.org/rylnd/shpec
+) [![Join the chat at https://gitter.im/rylnd/shpec](
+https://badges.gitter.im/Join%20Chat.svg)](
+https://gitter.im/rylnd/shpec?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+)
 ----
 
 *Test your shell scripts!*
@@ -21,22 +27,28 @@ Then to run your tests:
 shpec [shpec_files]
 ```
 
-If you'd like your tests to run automatically when they change, we recommend the [entr](http://entrproject.org/) utility:
+If you'd like your tests to run automatically when they change, we recommend the [entr](
+http://entrproject.org/) utility:
 
 ```bash
 find . -name "*_shpec.sh" | entr shpec
 ```
 ### Structuring your Tests
 `shpec` is similar to other *BDD* frameworks like
-[`RSpec`](https://github.com/rspec/rspec), [`Jasmine`](https://github.com/jasmine/jasmine), and [`mocha`](https://github.com/mochajs/mocha).
+[`RSpec`](
+https://github.com/rspec/rspec), [`Jasmine`](
+https://github.com/jasmine/jasmine), and [`mocha`](
+https://github.com/mochajs/mocha).
 
 The two main constructs are `describe/end` (used to group tests) and `it/end` (used to describe an individual test and wrap assertions).
 
 __Note:__ Since your test files will be sourced into `shpec`, you can use any shell command that would normally be available in your session.
 
 ### Examples
-[shpec's own tests](https://github.com/rylnd/shpec/tree/master/shpec/shpec_shpec.sh)
-are a great place to start. For more examples, see the [wiki page](https://github.com/rylnd/shpec/wiki/Examples)
+[shpec's own tests](
+https://github.com/rylnd/shpec/tree/master/shpec/shpec_shpec.sh)
+are a great place to start. For more examples, see the [wiki page](
+https://github.com/rylnd/shpec/wiki/Examples)
 
 ### Matchers
 The general format of an assertion is:
@@ -94,7 +106,8 @@ You can stub commands using `stub_command`.
 This function takes the name of the command you wish to stub. If provided, the second argument will be used as the body of the command. (code that would be evaluated)
 Once you're done, you can delete it with `unstub_command`.
 
-The best example is the [shpec test for this feature](https://github.com/rylnd/shpec/blob/master/shpec/shpec_shpec.sh#L72-L89).
+The best example is the [shpec test for this feature](
+https://github.com/rylnd/shpec/blob/master/shpec/shpec_shpec.sh#L72-L89).
 <!-- beware: keep in sync of line when modifying the shpec -->
 
 ## Installation
@@ -109,4 +122,20 @@ putting `antigen bundle rylnd/shpec` in your `.zshrc`
 ## Contributing
 Pull requests are always welcome.
 
-If you've got a test or custom matcher you're particularly proud of, please consider adding it to [the Examples page](https://github.com/rylnd/shpec/wiki/Examples)!
+### Style and code conventions
+Language: POSIX shell
+
+The core `shpec` script and function should work the same in
+any POSIX compliant shell.  You can use `shpec` to test scripts
+that use non-POSIX features, but you must avoid them when extending
+`shpec` or the main `shpec_shpech.sh` tests.
+
+Any variables starting with the `_shpec_` prefix are reserved
+for internal use and should not be used in test cases (except
+perhaps for test cases of `shpec` itself).
+
+
+
+If you've got a test or custom matcher you're particularly proud of,
+please consider adding it to [the Examples page](
+https://github.com/rylnd/shpec/wiki/Examples)!

--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-shpec [![Build Status](
-https://travis-ci.org/rylnd/shpec.png)](
-https://travis-ci.org/rylnd/shpec
-) [![Join the chat at https://gitter.im/rylnd/shpec](
-https://badges.gitter.im/Join%20Chat.svg)](
-https://gitter.im/rylnd/shpec?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
-)
+shpec [![Build Status](https://travis-ci.org/rylnd/shpec.png)](https://travis-ci.org/rylnd/shpec) [![Join the chat at https://gitter.im/rylnd/shpec](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/rylnd/shpec)
 ----
 
 *Test your shell scripts!*

--- a/bin/shpec
+++ b/bin/shpec
@@ -1,7 +1,7 @@
 # vim: set ft=sh:
 
 indent() {
-  printf '%*s' $(( (test_indent - 1) * 2))
+  printf '%*s' $(( (_shpec_indent - 1) * 2))
 }
 
 echoe() { printf "%b\n" "$*"; }
@@ -15,13 +15,13 @@ sanitize() {
 }
 
 describe() {
-  : $((test_indent += 1))
+  : $((_shpec_indent += 1))
   iecho "$1"
 }
 
 end() {
-  : $((test_indent -= 1))
-  [ $test_indent -ge 0 ] && return 0
+  : $((_shpec_indent -= 1))
+  [ $_shpec_indent -ge 0 ] && return 0
   echo >& 2 "shpec: $_shpec_file: unexpected 'end'"
   exit 1
 }
@@ -36,16 +36,16 @@ end_describe() {
 # any identifier as a function name.
 
 stub_command() {
-  body="${2:-:}"
-  eval "$1() { $body; }"
+  _shpec_stub_body="${2:-:}"
+  eval "$1() { ${_shpec_stub_body}; }"
 }
 
 unstub_command() { unset -f "$1"; }
 
 it() {
-  : $((test_indent += 1))
-  : $((examples += 1))
-  assertion="$1"
+  : $((_shpec_indent += 1))
+  : $((_shpec_examples += 1))
+  _shpec_assertion="$1"
 }
 
 is_function() {
@@ -109,8 +109,8 @@ assert() {
   ;;
   ( * )
     if is_function "$1"; then
-      matcher="$1"; shift
-      $matcher "$@"
+      _shpec_matcher="$1"; shift
+      $_shpec_matcher "$@"
       return 0
     else
       print_result false "Error: Unknown matcher [$1]"
@@ -121,61 +121,62 @@ assert() {
 
 print_result() {
   if eval "$1"; then
-    iecho "$green$assertion$norm"
+    iecho "$_shpec_green$_shpec_assertion$_shpec_norm"
   else
-    : $((failures += 1))
-    iecho "$red$assertion"
-    iecho "($2)$norm"
+    : $((_shpec_failures += 1))
+    iecho "$_shpec_red$_shpec_assertion"
+    iecho "($2)$_shpec_norm"
   fi
 }
 
 final_results() {
-  [ $failures -eq 0 ] && color=$green || color=$red
-  echoe "${color}${examples} examples, ${failures} failures${norm}"
+  [ $_shpec_failures -eq 0 ] && _shpec_color=$_shpec_green || _shpec_color=$_shpec_red
+  echoe "${_shpec_color}${_shpec_examples} examples, ${_shpec_failures} failures${_shpec_norm}"
   times
-  [ $failures -eq 0 ]
+  [ $_shpec_failures -eq 0 ]
   exit
 }
 
 
 shpec() {
   (
-    VERSION=0.2.1
+    _shpec_VERSION=0.2.1
     case "$1" in
     ( -v | --version )
-      echo "$VERSION"
+      echo "$_shpec_VERSION"
       exit 0
     ;;
     esac
 
-    examples=0
-    failures=0
-    test_indent=0
-    red="\033[0;31m"
-    green="\033[0;32m"
-    norm="\033[0m"
+    _shpec_examples=0
+    _shpec_failures=0
+    _shpec_indent=0
+    _shpec_red="\033[0;31m"
+    _shpec_green="\033[0;32m"
+    _shpec_norm="\033[0m"
 
-    SHPEC_ROOT=${SHPEC_ROOT:-$(
+    _shpec_root=${SHPEC_ROOT:-$(
       [ -d './shpec' ] && echo './shpec' || echo '.'
     )}
+    SHPEC_ROOT=${_shpec_root}
 
-    matcher_files=$(
-      find "$SHPEC_ROOT/matchers" -name '*.sh' 2>/dev/null
+    _shpec_matcher_files=$(
+      find "$_shpec_root/matchers" -name '*.sh' 2>/dev/null
     )
 
-    for matcher_file in $matcher_files; do
-      . "$matcher_file"
+    for _shpec_matcher_file in $_shpec_matcher_files; do
+      . "$_shpec_matcher_file"
     done
 
     if [ $# -gt 0 ] ; then
-      files="${*}"
+      _shpec_files="${*}"
     else
-      files=$(
-        find "$SHPEC_ROOT" -name '*_shpec.sh'
+      _shpec_files=$(
+        find "$_shpec_root" -name '*_shpec.sh'
       )
     fi
 
-    for _shpec_file in $files; do
+    for _shpec_file in $_shpec_files; do
       . "$_shpec_file"
     done
 

--- a/bin/shpec
+++ b/bin/shpec
@@ -137,13 +137,18 @@ final_results() {
   exit
 }
 
+shpec_version() {
+  (
+  VERSION=0.2.1
+  echo $VERSION
+  )
+}
 
 shpec() {
   (
-    _shpec_VERSION=0.2.1
     case "$1" in
     ( -v | --version )
-      echo "$_shpec_VERSION"
+      shpec_version
       exit 0
     ;;
     esac


### PR DESCRIPTION
As discussed, this adds a prefix _shpec_ to
all internal variables.

TODO:

* Documentation - wiki update

* Tests ?

* Dealing with colours.  I'm thinking we could use an
  ANSI colour plugin.  Somehow, prefixing $color, $red, and $green
  with _shpec_ does not feel right.