### PR TITLE
Use "POSIX" locale if processing `type` ouput

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -49,10 +49,18 @@ it() {
 }
 
 is_function() {
-  case $(LC_ALL=C type "$1" 2> /dev/null) in
-    (*function*) return 0;;
-  esac
-  return 1
+  (
+    a=$(command -v "$1") 2> /dev/null
+    case $a in
+    ($1)
+      b=$(unset -f "$1"; command -v "$1") 2> /dev/null
+      case $b in
+      ("") exit 0;;
+      esac
+    ;;
+    esac
+    return 1
+  )
 }
 
 assert() {

--- a/bin/shpec
+++ b/bin/shpec
@@ -49,7 +49,7 @@ it() {
 }
 
 is_function() {
-  case $(type "$1" 2> /dev/null) in
+  case $(LC_ALL=C type "$1" 2> /dev/null) in
     (*function*) return 0;;
   esac
   return 1

--- a/shpec/shell_compatibility_shpec.sh
+++ b/shpec/shell_compatibility_shpec.sh
@@ -6,7 +6,7 @@ describe "shell compatibility"
         . ./shpec.plugin.zsh
 
         it "defines a shpec alias"
-          shpec_type=$(type shpec | cut -d ' ' -f 4)
+          shpec_type=$(LC_ALL=C type shpec | cut -d ' ' -f 4)
           assert match ${shpec_type} "alias"
         end
 

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -110,6 +110,21 @@ line'
     it "allows custom matchers"
       assert custom_assertion "argument"
     end
+
+    it "works on locales other than English"
+      stub_command "type" '
+        lang="${LC_ALL-}"
+        ${lang:=$LC_MESSAGES}
+        ${lang:=$LANG}
+        case $lang in
+          C|POSIX) printf "function" ;;
+        esac'
+
+      LANG='fr_FR.UTF-8' LC_MESSAGES=$LANG \
+        assert custom_assertion "argument"
+
+      unstub_command "type"
+    end
   end
 
   describe "exit codes"


### PR DESCRIPTION
This fixes _custom matchers_ failing on many systems with a locale other than English (issue #90):

```
  custom matcher
    allows custom matchers
    (Error: Unknown matcher [custom_assertion])
```

The error is caused by `type` output being processed without specifying locale.
e.g. for French locale as the default:

``` bash
$ echo $LANG
fr_FR.UTF-8
$ f() { :; }
$ type f
f est une fonction
f () 
{ 
    :
}
```

Whereas with the "POSIX", a.k.a "C" locale specified for `type`:

``` bash
$ echo $LANG
fr_FR.UTF-8
$ f() { :; }
$ LC_ALL=C type f
f is a function
f () 
{ 
    :
}
```
- $LC_ALL overrides all other locale variables
  http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
- Use the "POSIX", a.k.a "C" locale:
  http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html
