### PR TITLE
Stub assert

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -61,7 +61,7 @@ unstub_assert()
 {
     unstub_command "assert"
     local definition="$(get_function_declaration _shpec____assert)"
-    local reverted="${definition/_shpec____/}"
+    local reverted="$(echo "${definition}" | sed 's/_shpec____//')"
 
     eval "${reverted}"
 }

--- a/bin/shpec
+++ b/bin/shpec
@@ -42,6 +42,30 @@ stub_command() {
 
 unstub_command() { unset -f "$1"; }
 
+get_function_declaration()
+{
+  if [ "${SHELL}" = "dash" ]; then
+    type "$1" | tail -n +2
+  else
+    typeset -f "$1"
+  fi
+}
+
+stub_assert()
+{
+    eval "_shpec____$(get_function_declaration assert)"
+    stub_command "assert" "$1"
+}
+
+unstub_assert()
+{
+    unstub_command "assert"
+    local definition="$(get_function_declaration _shpec____assert)"
+    local reverted="${definition/_shpec____/}"
+
+    eval "${reverted}"
+}
+
 it() {
   : $((_shpec_indent += 1))
   : $((_shpec_examples += 1))

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -86,6 +86,15 @@ line'
       assert equal "$(curl)" "stubbed body"
       unstub_command "curl"
     end
+
+    it "stubs shpec assert function"
+      local expected="assert double"
+      stub_assert "echo '${expected}'"
+      local result="$(assert)"
+      unstub_assert
+
+      assert equal "${expected}" "${result}"
+    end
   end
 
   describe "testing files"


### PR DESCRIPTION
Hi,

here is a little enhancement that provides a way to stub the shpec assert function.
It is useful to check its behaviour when it is nested in a function body, like in a matcher for example.

Best regards

Eric 