### PR TITLE
feat: allow other suffixes than .sh on shpec files

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -177,7 +177,7 @@ shpec() {
       _shpec_files="${*}"
     else
       _shpec_files=$(
-        find "$_shpec_root" -name '*_shpec.sh'
+        find "$_shpec_root" -name '*_shpec.*'
       )
     fi
 


### PR DESCRIPTION
Users like myself write bash-specific shpec files which more appropriately bear the .bash extension.  This is both to specify the acceptable syntax to other developers, as well as to hint syntax editors about the rules to apply.

It seems sufficient to me to define shpec files as any which end in _shpec.*, whatever the extension.  You could get more specific to create an expression which tests for .sh, .bash et. al., but I don't see any added value to that.

Cheers.