### PR TITLE
feature: spawn bash if all shpec files end with .bash; fixes #93

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -201,6 +201,7 @@ shpec() {
       )
     fi
 
+    # shellcheck disable=SC2086
     if ! ends_with bash "$(echo_shell)" && all ends_with .bash $_shpec_files; then
       exec bash -c "$0" "$_shpec_files"
     fi

--- a/bin/shpec
+++ b/bin/shpec
@@ -17,7 +17,7 @@ ends_with() {
 }
 
 echo_shell() {
-  ps -hp $$ | awk '{print $5}'
+  ps hp $$ | awk '{print $5}'
 }
 
 indent() {

--- a/bin/shpec
+++ b/bin/shpec
@@ -1,5 +1,25 @@
 # vim: set ft=sh:
 
+all() {
+  _shpec_all_func=$1
+  _shpec_all_arg=$2
+  shift 2
+
+  _shpec_all_result=0
+  for _shpec_all_item in "$@"; do
+    "$_shpec_all_func" "$_shpec_all_arg" "$_shpec_all_item" >/dev/null 2>&1 || _shpec_all_result=1
+  done
+  [ $_shpec_all_result -eq 0 ]
+}
+
+ends_with() {
+  [ ! "${2##*$1}" ]
+}
+
+echo_shell() {
+  ps -hp $$ | awk '{print $5}'
+}
+
 indent() {
   printf '%*s' $(( (_shpec_indent - 1) * 2))
 }
@@ -179,6 +199,10 @@ shpec() {
       _shpec_files=$(
         find "$_shpec_root" -name '*_shpec.*'
       )
+    fi
+
+    if ! ends_with bash "$(echo_shell)" && all ends_with .bash $_shpec_files; then
+      exec bash -c "$0" "$_shpec_files"
     fi
 
     for _shpec_file in $_shpec_files; do

--- a/bin/shpec
+++ b/bin/shpec
@@ -203,7 +203,7 @@ shpec() {
 
     # shellcheck disable=SC2086
     if ! ends_with bash "$(echo_shell)" && all ends_with .bash $_shpec_files; then
-      exec bash -c "$0" "$_shpec_files"
+      exec bash -c "$0 $_shpec_files"
     fi
 
     for _shpec_file in $_shpec_files; do

--- a/bin/shpec
+++ b/bin/shpec
@@ -40,6 +40,11 @@ describe() {
 }
 
 end() {
+  _shpec_last_result=$?
+  if [ $_shpec_indent -gt 1 ]; then
+    [ -z "$_shpec_subshell_test" ] && : $((_shpec_total_failures += _shpec_last_result))
+    : $((_shpec_failures += _shpec_total_failures ))
+  fi
   : $((_shpec_indent -= 1))
   [ $_shpec_indent -ge 0 ] && return 0
   echo >& 2 "shpec: $_shpec_file: unexpected 'end'"
@@ -66,6 +71,9 @@ it() {
   : $((_shpec_indent += 1))
   : $((_shpec_examples += 1))
   _shpec_assertion="$1"
+  unset -v _shpec_subshell_test
+  _shpec_total_failures=$_shpec_failures
+  _shpec_failures=0
 }
 
 is_function() {
@@ -76,6 +84,8 @@ is_function() {
 }
 
 assert() {
+  _shpec_subshell_test=true
+
   case "x$1" in
   ( xequal )
     print_result "[ '$(sanitize "$2")' = '$(sanitize "$3")' ]" \


### PR DESCRIPTION
This is a proof of concept that works, but I'm sure you'll want to think about it before deciding what to do.

I can only make this work for bash since that's all I'm working with, I'm not worrying about zsh or others.  I think they'd have to be handled on a case-by-case basis by folks who use them.

I've tested it by running shpec under sh, and it correctly execs bash if all of the shpec files end with ".bash".  If you're already running under bash, it doesn't exec anything.

It also fixes my problem with running bash-specific test files with entr, which was the main place I was having trouble with the proper shell detection.  entr apparently wouldn't run shpec with bash, so it was failing by trying to run my bash-specific tests under sh.  Btw, if you don't take this pull request, you might update the readme to suggest using "entr bash -c shpec [tests]" for bash tests since that was how I made it work before this.

It uses the bash on the user's path, presuming that's the correct one.  I'm not ready to make it any more complex than that.

Definitely open to discussion, I'm sure it's trickier than I may be giving it credit for.
