### PR TITLE
add (e)grep / no_(e)grep matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # shpec Changelog
 
 ## 0.2.3 Unreleased
+  * shpec files are no longer restricted to the .sh extension
 
 ## 0.2.2 (May 26, 2015)
   * Fix Antigen plugin to work with new shpec syntax

--- a/README.md
+++ b/README.md
@@ -63,8 +63,12 @@ equal         # equality
 unequal       # inequality
 gt            # algebraic '>'
 lt            # algebraic '<'
-match         # regex match
-no_match      # lack of regex match
+match         # regex match (glob style)
+no_match      # lack of regex match (glob style)
+grep          # regex match (grep style)
+no_grep       # lack of regex match (grep style)
+egrep         # regex match (egrep style)
+no_egrep      # lack of regex match (egrep style)
 ```
 
 #### Unary Matchers

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ equal         # equality
 unequal       # inequality
 gt            # algebraic '>'
 lt            # algebraic '<'
-match         # regex match (glob style)
-no_match      # lack of regex match (glob style)
+glob          # glob match
+no_glob       # lack of glob match
 grep          # regex match (grep style)
 no_grep       # lack of regex match (grep style)
 egrep         # regex match (egrep style)

--- a/bin/shpec
+++ b/bin/shpec
@@ -75,11 +75,11 @@ assert() {
       "Expected [$2] to be < [$3]"
   ;;
   ( xglob )
-    print_result "case '$2' in *$3*) :;; *) false;; esac" \
+    print_result "case '$2' in $3) :;; *) false;; esac" \
       "Expected [$2] to match [$3]"
   ;;
   ( xno_glob )
-    print_result "case '$2' in *$3*) false ;; *) :;; esac" \
+    print_result "case '$2' in $3) false ;; *) :;; esac" \
       "Expected [$2] not to match [$3]"
   ;;
   ( xpresent )

--- a/bin/shpec
+++ b/bin/shpec
@@ -107,6 +107,18 @@ assert() {
     print_result "$2" \
       "Expected $2 to be true"
   ;;
+  ( xgrep )
+    print_result "echo $2 | grep -q $3" "Expected $2 to match $3"
+  ;;
+  ( xno_grep )
+    print_result "echo $2 | grep -qv $3" "Expected $2 to not match $3"
+  ;;
+  ( xegrep )
+    print_result "echo $2 | egrep -q $3" "Expected $2 to match $3"
+  ;;
+  ( xno_egrep )
+    print_result "echo $2 | egrep -qv $3" "Expected $2 to not match $3"
+  ;;
   ( * )
     if is_function "$1"; then
       _shpec_matcher="$1"; shift

--- a/bin/shpec
+++ b/bin/shpec
@@ -108,16 +108,16 @@ assert() {
       "Expected $2 to be true"
   ;;
   ( xgrep )
-    print_result "echo $2 | grep -q $3" "Expected $2 to match $3"
+    print_result "echo $2 | grep -q \"$3\"" "Expected $2 to match $3"
   ;;
   ( xno_grep )
-    print_result "echo $2 | grep -qv $3" "Expected $2 to not match $3"
+    print_result "echo $2 | grep -qv \"$3\"" "Expected $2 to not match $3"
   ;;
   ( xegrep )
-    print_result "echo $2 | egrep -q $3" "Expected $2 to match $3"
+    print_result "echo $2 | egrep -q \"$3\"" "Expected $2 to match $3"
   ;;
   ( xno_egrep )
-    print_result "echo $2 | egrep -qv $3" "Expected $2 to not match $3"
+    print_result "echo $2 | egrep -qv \"$3\"" "Expected $2 to not match $3"
   ;;
   ( * )
     if is_function "$1"; then

--- a/bin/shpec
+++ b/bin/shpec
@@ -74,11 +74,11 @@ assert() {
     print_result "[ $2 -lt $3 ]" \
       "Expected [$2] to be < [$3]"
   ;;
-  ( xmatch )
+  ( xglob )
     print_result "case '$2' in *$3*) :;; *) false;; esac" \
       "Expected [$2] to match [$3]"
   ;;
-  ( xno_match )
+  ( xno_glob )
     print_result "case '$2' in *$3*) false ;; *) :;; esac" \
       "Expected [$2] not to match [$3]"
   ;;

--- a/bin/shpec
+++ b/bin/shpec
@@ -109,16 +109,16 @@ assert() {
       "Expected $2 to be true"
   ;;
   ( xgrep )
-    print_result "echo \"$2\" | grep -q \"$3\"" "Expected $2 to match $3"
+    print_result "echo \"$2\" | grep -q \"$3\"" "Expected [$2] to match [$3]"
   ;;
   ( xno_grep )
-    print_result "echo \"$2\" | grep -qv \"$3\"" "Expected $2 to not match $3"
+    print_result "echo \"$2\" | grep -qv \"$3\"" "Expected [$2] to not match [$3]"
   ;;
   ( xegrep )
-    print_result "echo \"$2\" | egrep -q \"$3\"" "Expected $2 to match $3"
+    print_result "echo \"$2\" | egrep -q \"$3\"" "Expected [$2] to match [$3]"
   ;;
   ( xno_egrep )
-    print_result "echo \"$2\" | egrep -qv \"$3\"" "Expected $2 to not match $3"
+    print_result "echo \"$2\" | egrep -qv \"$3\"" "Expected [$2] to not match [$3]"
   ;;
   ( * )
     if is_function "$1"; then

--- a/bin/shpec
+++ b/bin/shpec
@@ -108,16 +108,16 @@ assert() {
       "Expected $2 to be true"
   ;;
   ( xgrep )
-    print_result "echo $2 | grep -q \"$3\"" "Expected $2 to match $3"
+    print_result "echo \"$2\" | grep -q \"$3\"" "Expected $2 to match $3"
   ;;
   ( xno_grep )
-    print_result "echo $2 | grep -qv \"$3\"" "Expected $2 to not match $3"
+    print_result "echo \"$2\" | grep -qv \"$3\"" "Expected $2 to not match $3"
   ;;
   ( xegrep )
-    print_result "echo $2 | egrep -q \"$3\"" "Expected $2 to match $3"
+    print_result "echo \"$2\" | egrep -q \"$3\"" "Expected $2 to match $3"
   ;;
   ( xno_egrep )
-    print_result "echo $2 | egrep -qv \"$3\"" "Expected $2 to not match $3"
+    print_result "echo \"$2\" | egrep -qv \"$3\"" "Expected $2 to not match $3"
   ;;
   ( * )
     if is_function "$1"; then

--- a/shpec/shell_compatibility_shpec.sh
+++ b/shpec/shell_compatibility_shpec.sh
@@ -7,7 +7,7 @@ describe "shell compatibility"
 
         it "defines a shpec alias"
           shpec_type=$(type shpec | cut -d ' ' -f 4)
-          assert match ${shpec_type} "alias"
+          assert glob ${shpec_type} "alias"
         end
 
         it "alias that works normally"

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -16,18 +16,6 @@ describe "shpec"
       assert gt 7 5
     end
 
-    it "asserts partial globs"
-      assert glob "partially" "partial"
-    end
-
-    it "asserts  globs which are not compatible with grep"
-      assert glob "loooooooooooooooooong" "l*ng"
-    end
-
-    it "asserts lack of partial globs"
-      assert no_glob "zebra" "giraffe"
-    end
-
     it "asserts presence"
       assert present "something"
     end
@@ -63,6 +51,36 @@ line'
   describe "gt matcher"
     it "handles numbers of different length properly"
       assert gt 17 5
+    end
+  end
+
+  describe "glob matcher"
+    it "is essentially 'assert equal' if no special characters are used"
+      assert glob "word" "word"
+    end
+
+    it "supports multi-character wildcards"
+      assert glob "impartially" "*partial*"
+    end
+
+    it "supports single-character wildcards"
+      assert glob "word" "wo?d"
+      assert no_glob "world" "wo?d"
+    end
+
+    it "supports character lists"
+      assert glob "foo" "[a-f]oo"
+      assert no_glob "foo" "[g-z]oo"
+      assert glob "boo" "[a-z]oo"
+      assert glob "bar" "[a-z]*"
+    end
+
+    it "asserts globs which are not compatible with grep"
+      assert glob "loooooooooooooooooong" "l*ng"
+    end
+
+    it "asserts lack of globs"
+      assert no_glob "zebra" "giraffe"
     end
   end
 

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -176,26 +176,26 @@ line'
   describe "output"
     it "outputs passing tests to STDOUT"
       message="$(. $SHPEC_ROOT/etc/passing_example)"
-      assert glob "$message" "a\ passing\ test"
+      assert grep "$message" "a passing test"
     end
 
     it "outputs failing tests to STDOUT"
       message="$(. $SHPEC_ROOT/etc/failing_example)"
-      assert glob "$message" "a\ failing\ test"
+      assert grep "$message" "a failing test"
     end
 
     it "joins multiple identical assert names"
       output="$(. $SHPEC_ROOT/etc/multi_assert_example)"
 
-      assert glob "$output" "a\ assert*multi\ assert*x[0-9]*another\ assert"
+      assert glob "$output" "*a\ assert*multi\ assert*x[0-9]*another\ assert*"
     end
 
     it "doesn't join FAILED identical assert names"
-        output="$(. $SHPEC_ROOT/etc/multi_assert_fail_example)"
+      output="$(. $SHPEC_ROOT/etc/multi_assert_fail_example)"
 
-        assert glob "$output" "assert\ with\ errors*assert\ with\ errors"
-        assert glob "$output" "Expected\ \[1\]\ to\ equal\ \[2\]"
-        assert no_glob "$output" "x[0-9]*"
+      assert glob "$output" "*assert\ with\ errors*assert\ with\ errors*"
+      assert grep "$output" "Expected \[1\] to equal \[2\]"
+      assert no_grep "$output" "x[0-9]*"
     end
   end
 
@@ -209,7 +209,7 @@ line'
     it "informs you of the malformed shpec test file"
       shpec $_f > /tmp/syntax_error_output 2>& 1
       message="$(cat /tmp/syntax_error_output)"
-      assert glob "$message" "$_f"
+      assert grep "$message" "$_f"
     end
   end
 
@@ -218,14 +218,14 @@ line'
     describe "--version"
       it "outputs the current version number"
         message="$(shpec --version)"
-        assert glob "$message" "$(cat $SHPEC_ROOT/../VERSION)"
+        assert grep "$message" "$(cat $SHPEC_ROOT/../VERSION)"
       end
     end
 
     describe "-v"
       it "outputs the current version number"
         message="$(shpec -v)"
-        assert glob "$message" "$(cat $SHPEC_ROOT/../VERSION)"
+        assert grep "$message" "$(cat $SHPEC_ROOT/../VERSION)"
       end
     end
   end
@@ -233,7 +233,7 @@ line'
   describe "compatibility"
     it "works with old-style syntax"
       message="$(. $SHPEC_ROOT/etc/old_example)"
-      assert glob "$message" "old\ example"
+      assert grep "$message" "old example"
     end
   end
 end

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -63,6 +63,30 @@ line'
     end
   end
 
+  describe "grep matcher"
+    it "handles regex properly"
+        assert grep "hello" "^[a-z]*$"
+    end
+  end
+
+  describe "no_grep matcher"
+    it "handles regex properly"
+        assert no_grep "hello1" "^[a-z]*$"
+    end
+  end
+
+  describe "egrep matcher"
+    it "handles regex extended properly"
+        assert egrep "hello" "^[a-z]+$"
+    end
+  end
+
+  describe "no_egrep matcher"
+    it "handles regex extended properly"
+        assert no_egrep "hello1" "^[a-z]+$"
+    end
+  end
+
   describe "passing through to the test builtin"
     it "asserts an arbitrary algebraic test"
       assert test "[ 5 -lt 10 ]"

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -16,12 +16,16 @@ describe "shpec"
       assert gt 7 5
     end
 
-    it "asserts partial matches"
-      assert match "partially" "partial"
+    it "asserts partial globs"
+      assert glob "partially" "partial"
     end
 
-    it "asserts lack of partial matches"
-      assert no_match "zebra" "giraffe"
+    it "asserts  globs which are not compatible with grep"
+      assert glob "loooooooooooooooooong" "l*ng"
+    end
+
+    it "asserts lack of partial globs"
+      assert no_glob "zebra" "giraffe"
     end
 
     it "asserts presence"
@@ -150,26 +154,26 @@ line'
   describe "output"
     it "outputs passing tests to STDOUT"
       message="$(. $SHPEC_ROOT/etc/passing_example)"
-      assert match "$message" "a\ passing\ test"
+      assert glob "$message" "a\ passing\ test"
     end
 
     it "outputs failing tests to STDOUT"
       message="$(. $SHPEC_ROOT/etc/failing_example)"
-      assert match "$message" "a\ failing\ test"
+      assert glob "$message" "a\ failing\ test"
     end
 
     it "joins multiple identical assert names"
       output="$(. $SHPEC_ROOT/etc/multi_assert_example)"
 
-      assert match "$output" "a\ assert*multi\ assert*x[0-9]*another\ assert"
+      assert glob "$output" "a\ assert*multi\ assert*x[0-9]*another\ assert"
     end
 
     it "doesn't join FAILED identical assert names"
         output="$(. $SHPEC_ROOT/etc/multi_assert_fail_example)"
 
-        assert match "$output" "assert\ with\ errors*assert\ with\ errors"
-        assert match "$output" "Expected\ \[1\]\ to\ equal\ \[2\]"
-        assert no_match "$output" "x[0-9]*"
+        assert glob "$output" "assert\ with\ errors*assert\ with\ errors"
+        assert glob "$output" "Expected\ \[1\]\ to\ equal\ \[2\]"
+        assert no_glob "$output" "x[0-9]*"
     end
   end
 
@@ -183,7 +187,7 @@ line'
     it "informs you of the malformed shpec test file"
       shpec $_f > /tmp/syntax_error_output 2>& 1
       message="$(cat /tmp/syntax_error_output)"
-      assert match "$message" "$_f"
+      assert glob "$message" "$_f"
     end
   end
 
@@ -192,14 +196,14 @@ line'
     describe "--version"
       it "outputs the current version number"
         message="$(shpec --version)"
-        assert match "$message" "$(cat $SHPEC_ROOT/../VERSION)"
+        assert glob "$message" "$(cat $SHPEC_ROOT/../VERSION)"
       end
     end
 
     describe "-v"
       it "outputs the current version number"
         message="$(shpec -v)"
-        assert match "$message" "$(cat $SHPEC_ROOT/../VERSION)"
+        assert glob "$message" "$(cat $SHPEC_ROOT/../VERSION)"
       end
     end
   end
@@ -207,7 +211,7 @@ line'
   describe "compatibility"
     it "works with old-style syntax"
       message="$(. $SHPEC_ROOT/etc/old_example)"
-      assert match "$message" "old\ example"
+      assert glob "$message" "old\ example"
     end
   end
 end

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -85,26 +85,30 @@ line'
   end
 
   describe "grep matcher"
-    it "handles regex properly"
-        assert grep "hello" "^[a-z]*$"
+    it "supports matching regular expressions"
+      assert grep "hello" "^[a-z]*$"
     end
-  end
 
-  describe "no_grep matcher"
-    it "handles regex properly"
-        assert no_grep "hello1" "^[a-z]*$"
+    it "supports lack of matching regular expressions"
+      assert no_grep "hello1" "^[a-z]*$"
+    end
+
+    it "does not match multiple lines in a single expression"
+      output="$(. $SHPEC_ROOT/etc/multi_assert_example)"
+
+      assert grep "$output" "a assert"
+      assert grep "$output" "multi assert"
+      assert no_grep "$output" "a assert.*multi assert"
     end
   end
 
   describe "egrep matcher"
-    it "handles regex extended properly"
-        assert egrep "hello" "^[a-z]+$"
+    it "supports matching extended regular expressions"
+      assert egrep "hello" "^[a-z]+$"
     end
-  end
 
-  describe "no_egrep matcher"
-    it "handles regex extended properly"
-        assert no_egrep "hello1" "^[a-z]+$"
+    it "supports lack of matching extended regular expressions"
+      assert no_egrep "hello1" "^[a-z]+$"
     end
   end
 


### PR DESCRIPTION
# What?

This pullrequest addresses both parts of #96 
it fixes the documentation in the `README.md` and brings regex_matcher using grep and egrep
# Why?

I need regex matching to test output of shellscripts, using an extra variable und call grep or egrep in tests is inconvinient
# How was it tested?

with shpec of course, I've added test-cases for all 4 matchers.
