### PR TITLE
add subshell support for tests

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -20,6 +20,11 @@ describe() {
 }
 
 end() {
+  _shpec_last_result=$?
+  if [ $_shpec_indent -gt 1 ]; then
+    [ -z "$_shpec_subshell_test" ] && : $((_shpec_total_failures += _shpec_last_result))
+    : $((_shpec_failures += _shpec_total_failures ))
+  fi
   : $((_shpec_indent -= 1))
   [ $_shpec_indent -ge 0 ] && return 0
   echo >& 2 "shpec: $_shpec_file: unexpected 'end'"
@@ -46,6 +51,9 @@ it() {
   : $((_shpec_indent += 1))
   : $((_shpec_examples += 1))
   _shpec_assertion="$1"
+  unset -v _shpec_subshell_test
+  _shpec_total_failures=$_shpec_failures
+  _shpec_failures=0
 }
 
 is_function() {
@@ -56,6 +64,8 @@ is_function() {
 }
 
 assert() {
+  _shpec_subshell_test=true
+
   case "x$1" in
   ( xequal )
     print_result "[ '$(sanitize "$2")' = '$(sanitize "$3")' ]" \


### PR DESCRIPTION
This is a proof-of-concept for subshell support in tests.  It is an optional feature, in that normal test syntax without subshells works the same as it always has, but now also allow for subshells if you follow a couple new rules.

The basic idea is to provide the option for a test to perform its job inside a subshell (parentheses subshells, not normal subprocesses which happen to be shells).  Normally, the changes to the _shpec_failures variable are lost in a subshell, which messes up the reported statistics at the end of a shpec run.  This modification allows tests to be written inside a subshell, provided that they return the _shpec_failures variable like so:

```
describe "my test"
  it "should run in a subshell"; (
    assert equal 0 1
    return $_shpec_failures )
  end
end
```

The use case is so that test cases with a lot of state can be kept independent of other tests and won't accidentally bleed over into them.  One example is when an individual test might need to source another file which isn't relevant to the rest of the tests in the shpec:

```
describe "my messy test"
  it "shouldn't let its context affect other tests"; (
    . a_whole_bunch_of_garbage.sh
    that_one_function_i "needed" >/dev/null
    assert equal 0 $?
    return $_shpec_failures )
  end
end
```

It can also help prevent subtle bugs from accidental reuse of a variable formerly used as an array and now as a string variable.  String indexing and array indexing interfere with each other, so type matters when the variable name has been used before.  Arrays aren't automatically recast down to strings, which causes the heartburn.

The way this code works is to modify the `it`, `assert` and `end` functions to test if a subshell is in use within the test.

The presumption is that the subshell comes after an `it` call and returns right before an `end` call.  The presumption is also that the end must be with at least one level of indent (perhaps it should only be equal to one level, not >=?).

The code starts with the `it` function, which moves the running _shpec_failures count into a _shpec_total_failures variable and resets _shpec_failures to zero. If there is no subshell, _shpec_failures will track failures normally and at the end will have the total failures added back into it, so that the final statistics code is untouched and still relies on the _shpec_failures variable.

The `assert` function sets a flag to test for the subshell, called _shpec_subshell_test.  If a subshell is in use, the `assert` will be inside it and the variable will not exist later when `end` is called outside the subshell.

If the `end` of the appropriate indent doesn't see that variable set, it concludes that the test was in a subshell and that instead of relying on _shpec_failures (should be zero in this shell, since the subshell's count was also lost), the subshell has `return`ed its own _shpec_failures count as its return value.  It grabs this value as _shpec_last_return and adds it into total_failures before the aforementioned addition of total failures back into _shpec_failures.

This is a little more byzantine than I'd like, but it works and only changes the smallest amount of code I could think of.  It works in bash.  I haven't tested it with other shells but did try to write it posixy, and I don't see why it wouldn't work for them.