### PR TITLE
Minor CLI improvement

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -168,7 +168,7 @@ shpec() {
     _shpec_red="\033[0;31m"
     _shpec_green="\033[0;32m"
     _shpec_norm="\033[0m"
-    _shpec_clear_ln="\e[1A\033[K"
+    _shpec_clear_ln="\033[1A\033[K"
 
     _shpec_root=${SHPEC_ROOT:-$(
       [ -d './shpec' ] && echo './shpec' || echo '.'

--- a/bin/shpec
+++ b/bin/shpec
@@ -127,8 +127,8 @@ print_result() {
     if [ ${_shpec_assertion_printed} -eq 1 ]; then
       iecho "$_shpec_green$_shpec_assertion$_shpec_norm"
     else
-        printf "%b" "$_shpec_clear_ln"
-        iecho "$_shpec_green$_shpec_assertion$_shpec_norm(x$_shpec_assertion_printed)"
+      printf "%b" "$_shpec_clear_ln"
+      iecho "$_shpec_green$_shpec_assertion$_shpec_norm(x$_shpec_assertion_printed)"
     fi
   else
     : $((_shpec_failures += 1))

--- a/bin/shpec
+++ b/bin/shpec
@@ -126,7 +126,8 @@ print_result() {
     if [[ ${_shpec_assertion_printed} -eq 1 ]]; then
       iecho "$_shpec_green$_shpec_assertion$_shpec_norm"
     else
-        iecho "$_shpec_clear_ln$_shpec_green$_shpec_assertion$_shpec_norm(x$_shpec_assertion_printed)"
+        iecho "$_shpec_clear_ln"\
+              "$_shpec_green$_shpec_assertion$_shpec_norm(x$_shpec_assertion_printed)"
     fi
   else
     : $((_shpec_failures += 1))
@@ -166,7 +167,6 @@ shpec() {
     _shpec_red="\033[0;31m"
     _shpec_green="\033[0;32m"
     _shpec_norm="\033[0m"
-
     _shpec_clear_ln="\e[1A\033[K"
 
     _shpec_root=${SHPEC_ROOT:-$(

--- a/bin/shpec
+++ b/bin/shpec
@@ -123,11 +123,11 @@ assert() {
 print_result() {
   if eval "$1"; then
     : $((_shpec_assertion_printed += 1))
-    if [[ ${_shpec_assertion_printed} -eq 1 ]]; then
+    if [ ${_shpec_assertion_printed} -eq 1 ]; then
       iecho "$_shpec_green$_shpec_assertion$_shpec_norm"
     else
-        iecho "$_shpec_clear_ln"\
-              "$_shpec_green$_shpec_assertion$_shpec_norm(x$_shpec_assertion_printed)"
+        echo -en "$_shpec_clear_ln"
+        iecho "$_shpec_green$_shpec_assertion$_shpec_norm(x$_shpec_assertion_printed)"
     fi
   else
     : $((_shpec_failures += 1))

--- a/bin/shpec
+++ b/bin/shpec
@@ -1,3 +1,4 @@
+#!/usr/bin/sh
 # vim: set ft=sh:
 
 indent() {
@@ -126,7 +127,7 @@ print_result() {
     if [ ${_shpec_assertion_printed} -eq 1 ]; then
       iecho "$_shpec_green$_shpec_assertion$_shpec_norm"
     else
-        echo -en "$_shpec_clear_ln"
+        printf "%b" "$_shpec_clear_ln"
         iecho "$_shpec_green$_shpec_assertion$_shpec_norm(x$_shpec_assertion_printed)"
     fi
   else

--- a/bin/shpec
+++ b/bin/shpec
@@ -1,4 +1,3 @@
-#!/usr/bin/sh
 # vim: set ft=sh:
 
 indent() {

--- a/bin/shpec
+++ b/bin/shpec
@@ -21,6 +21,7 @@ describe() {
 
 end() {
   : $((_shpec_indent -= 1))
+  _shpec_assertion_printed=0
   [ $_shpec_indent -ge 0 ] && return 0
   echo >& 2 "shpec: $_shpec_file: unexpected 'end'"
   exit 1
@@ -121,9 +122,15 @@ assert() {
 
 print_result() {
   if eval "$1"; then
-    iecho "$_shpec_green$_shpec_assertion$_shpec_norm"
+    : $((_shpec_assertion_printed += 1))
+    if [[ ${_shpec_assertion_printed} -eq 1 ]]; then
+      iecho "$_shpec_green$_shpec_assertion$_shpec_norm"
+    else
+        iecho "$_shpec_clear_ln$_shpec_green$_shpec_assertion$_shpec_norm(x$_shpec_assertion_printed)"
+    fi
   else
     : $((_shpec_failures += 1))
+    _shpec_assertion_printed=0
     iecho "$_shpec_red$_shpec_assertion"
     iecho "($2)$_shpec_norm"
   fi
@@ -159,6 +166,8 @@ shpec() {
     _shpec_red="\033[0;31m"
     _shpec_green="\033[0;32m"
     _shpec_norm="\033[0m"
+
+    _shpec_clear_ln="\e[1A\033[K"
 
     _shpec_root=${SHPEC_ROOT:-$(
       [ -d './shpec' ] && echo './shpec' || echo '.'

--- a/bin/shpec
+++ b/bin/shpec
@@ -124,7 +124,7 @@ assert() {
 print_result() {
   if eval "$1"; then
     : $((_shpec_assertion_printed += 1))
-    if [ ${_shpec_assertion_printed} -eq 1 ]; then
+    if [ ${_shpec_assertion_printed} -le 1 ]; then
       iecho "$_shpec_green$_shpec_assertion$_shpec_norm"
     else
       printf "%b" "$_shpec_clear_ln"

--- a/shpec/etc/multi_assert_example
+++ b/shpec/etc/multi_assert_example
@@ -1,4 +1,12 @@
-it "joins multi asserts"
-  assert equal "foo" "foo"
-  assert equal "foo" "foo"
+it "a assert"
+  assert equal 1 1
+end
+
+it "multi assert"
+  assert equal 1 1
+  assert equal 2 2
+end
+
+it "another assert"
+  assert equal 1 1
 end

--- a/shpec/etc/multi_assert_example
+++ b/shpec/etc/multi_assert_example
@@ -1,0 +1,4 @@
+it "joins multi asserts"
+  assert equal "foo" "foo"
+  assert equal "foo" "foo"
+end

--- a/shpec/etc/multi_assert_fail_example
+++ b/shpec/etc/multi_assert_fail_example
@@ -1,0 +1,5 @@
+it "assert with errors"
+  assert equal 1 1
+  assert equal 1 2
+  assert equal 3 3
+end

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -142,9 +142,9 @@ line'
       # 3) remove all color escape chars
       # 4) remove all ascii formating characters expect newlines (whitespace)
       output="$(shpec $SHPEC_ROOT/etc/multi_assert_example |
-                    head --lines=-3 |
+                    head -n -3 |
                     sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" |
-                    tr --delete --complement '\n[:print:]'
+                    tr -d -c '\n[:print:]'
                )"
 
       expected="a assert"

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -143,19 +143,17 @@ line'
       # 2) remove all output wich does not have the relevant test (i.e. _expected)
       # 3) remove all color escape chars
       # 4) remove all ascii formating characters (whitespace)
-      message="$(shpec $SHPEC_ROOT/etc/multi_assert_example\
-                 | grep "${_expected}"\
-                 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"\
-                 | tr -dc '[:print:]'\
+      message="$(shpec $SHPEC_ROOT/etc/multi_assert_example \
+                 | grep "${_expected}" \
+                 | sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" \
+                 | tr --delete --complement '[:print:]' \
                 )"
 
-      # deletes part of string wich is not shown due to the clearln char
+      # deletes the part of the string wich is present, but is not shown by the
+      # terminal due to the clearln character.
       message="${message##*[1A}"
 
-      # can't use a 'assert test' or 'assert equal' because the strings to
-      # compare have non escapable chars
-      [ "${message}" = "${_expected}(x2)" ]
-      assert equal $? 0
+      assert test "[ \"${message}\" = \"${_expected}(x2)\" ]"
     end
   end
 

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -136,24 +136,23 @@ line'
     end
 
     it "joins multiple identical assert names"
-      _expected="joins multi asserts"
-
       # the following pipe does
       # 1) run shpec in multi_assert_example
-      # 2) remove all output wich does not have the relevant test (i.e. _expected)
+      # 2) remove shepec's final results section
       # 3) remove all color escape chars
       # 4) remove all ascii formating characters (whitespace)
-      message="$(shpec $SHPEC_ROOT/etc/multi_assert_example \
-                 | grep "${_expected}" \
-                 | sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" \
-                 | tr --delete --complement '[:print:]' \
-                )"
+      output="$(shpec $SHPEC_ROOT/etc/multi_assert_example |
+                    head --lines=-3 |
+                    sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" |
+                    tr --delete --complement '\n[:print:]'
+               )"
 
-      # deletes the part of the string wich is present, but is not shown by the
-      # terminal, due to the clearln character.
-      message=${message##*'[1A'}
+      expected="a assert"
+      expected="${expected}\nmulti assert" # which is present in the string but hidden in the terminal
+      expected="${expected}\n[1Amulti assert(x2)"
+      expected="${expected}\nanother assert"
 
-      assert equal "${message}" "${_expected}(x2)"
+      assert equal "${output}" "${expected}"
     end
   end
 

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -140,7 +140,7 @@ line'
       # 1) run shpec in multi_assert_example
       # 2) remove shepec's final results section
       # 3) remove all color escape chars
-      # 4) remove all ascii formating characters (whitespace)
+      # 4) remove all ascii formating characters expect newlines (whitespace)
       output="$(shpec $SHPEC_ROOT/etc/multi_assert_example |
                     head --lines=-3 |
                     sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" |
@@ -153,6 +153,23 @@ line'
       expected="${expected}\nanother assert"
 
       assert equal "${output}" "${expected}"
+    end
+
+
+    it "doesn't join FAILED identical assert names"
+        # see previous test
+        output="$(shpec $SHPEC_ROOT/etc/multi_assert_fail_example |
+                        head --lines=-3 |
+                        sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" |
+                        tr --delete --complement '\n[:print:]'
+                )"
+
+        expected="assert with errors"
+        expected="${expected}\nassert with errors"
+        expected="${expected}\n(Expected [1] to equal [2])"
+        expected="${expected}\nassert with errors"
+
+        assert equal "${output}" "${expected}"
     end
   end
 

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -134,6 +134,29 @@ line'
       message="$(. $SHPEC_ROOT/etc/failing_example)"
       assert match "$message" "a\ failing\ test"
     end
+
+    it "joins multiple identical assert names"
+      _expected="joins multi asserts"
+
+      # the following pipe does
+      # 1) run shpec in multi_assert_example
+      # 2) remove all output wich does not have the relevant test (i.e. _expected)
+      # 3) remove all color escape chars
+      # 4) remove all ascii formating characters (whitespace)
+      message="$(shpec $SHPEC_ROOT/etc/multi_assert_example\
+                 | grep "${_expected}"\
+                 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"\
+                 | tr -dc '[:print:]'\
+                )"
+
+      # deletes part of string wich is not shown due to the clearln char
+      message="${message##*[1A}"
+
+      # can't use a 'assert test' or 'assert equal' because the strings to
+      # compare have non escapable chars
+      [ "${message}" = "${_expected}(x2)" ]
+      assert equal $? 0
+    end
   end
 
   describe "malformed test files"

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -150,10 +150,12 @@ line'
                 )"
 
       # deletes the part of the string wich is present, but is not shown by the
-      # terminal due to the clearln character.
-      message="${message##*[1A}"
+      # terminal, due to the clearln character.
+      echo $message
+      message=${message##*'[1A'}
+      echo $message
 
-      assert test "[ \"${message}\" = \"${_expected}(x2)\" ]"
+      assert equal "${message}" "${_expected}(x2)"
     end
   end
 

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -151,9 +151,7 @@ line'
 
       # deletes the part of the string wich is present, but is not shown by the
       # terminal, due to the clearln character.
-      echo $message
       message=${message##*'[1A'}
-      echo $message
 
       assert equal "${message}" "${_expected}(x2)"
     end

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -142,7 +142,7 @@ line'
       # 3) remove all color escape chars
       # 4) remove all ascii formating characters expect newlines (whitespace)
       output="$(shpec $SHPEC_ROOT/etc/multi_assert_example |
-                    head -n -3 |
+                    sed "5,\$d" |
                     sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" |
                     tr -d -c '\n[:print:]'
                )"
@@ -159,9 +159,9 @@ line'
     it "doesn't join FAILED identical assert names"
         # see previous test
         output="$(shpec $SHPEC_ROOT/etc/multi_assert_fail_example |
-                        head --lines=-3 |
+                        sed "5,\$d" |
                         sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" |
-                        tr --delete --complement '\n[:print:]'
+                        tr -d -c '\n[:print:]'
                 )"
 
         expected="assert with errors"


### PR DESCRIPTION
Hello,

This is a simple quality of life enhancement to improve the output of shepc when
dealing with it/end blocks with multiple asserts.

Previously if a multiple asserts existed inside a it/end block, when running the
tests, shpec would output:
```
describe block text
     it block text
        assert message
        assert message
        assert message
...
```

But with this pull request it would output:
```
describe block text
     it block text
        assert message(x3)
...
```
