### PR TITLE
Add BSD userland to CI suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,19 @@ env:
     - SHELL=ksh
     - SHELL=zsh
 matrix:
+  include:
+    - os: osx
+      env: SHELL=bash
+  exclude:
+    - os: osx
   fast_finish: true
+os:
+  - linux
+  - osx
 script:
   - |
     $SHELL --version
+
     if [ "$SHELL" = "zsh" ]; then
       cat > $HOME/.zshenv <<END
         disable -r end
@@ -26,27 +35,29 @@ script:
     fi
 before_install:
   - |
-    get_shellcheck() {
-      (
-      for v
-      do
-        pkg=shellcheck_${v}_amd64.deb
-        url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
-        wget $url/$pkg || continue
-        echo $pkg
-        break
-      done
-      )
-    }
-    install_shell(){
-      echo "Install $SHELL"
-      sudo apt-get update -qq
-      sudo apt-get install -y $SHELL
-    }
+    if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+      get_shellcheck() {
+        (
+        for v
+        do
+          pkg=shellcheck_${v}_amd64.deb
+          url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
+          wget $url/$pkg || continue
+          echo $pkg
+          break
+        done
+        )
+      }
+      install_shell(){
+        echo "Install $SHELL"
+        sudo apt-get update -qq
+        sudo apt-get install -y $SHELL
+      }
 
-    if ${LINT:-false}; then
-      pkg=$( get_shellcheck 0.3.5-3 0.3.4-3 )
-      sudo dpkg -i $pkg
-    elif ! type $SHELL > /dev/null; then
-      install_shell
+      if ${LINT:-false}; then
+        pkg=$( get_shellcheck 0.3.5-3 0.3.4-3 )
+        sudo dpkg -i $pkg
+      elif ! type $SHELL > /dev/null; then
+        install_shell
+      fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: sh
+cache: apt
 env:
   matrix:
     - LINT=true
@@ -23,7 +24,6 @@ script:
     else
       $SHELL bin/shpec
     fi
-cache: apt
 before_install:
   - |
     get_shellcheck() {


### PR DESCRIPTION
Addresses #101.

This _works_, but there are two issues:
1. The OSX VMs on Travis are slow(er) and also in high demand (see the [Backlog OS X Builds for Open Source Projects graph on their status page](https://www.traviscistatus.com/)). Things seem to be acceptable right now, but initial testing showed build latencies [as high as 35 minutes](https://travis-ci.org/rylnd/shpec/builds/199498833).
2. The suite is broken on BSD :(. This was caused by #100, which falls on me for not performing due diligence before merging.

Despite the latter issue, I would like to get this merged so that we have a clear indication of when the existing issue on master is fixed.