### PR TITLE
Fix assertion-grouping specs for BSD userland

### DIFF
--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -135,40 +135,17 @@ line'
     end
 
     it "joins multiple identical assert names"
-      # the following pipe does
-      # 1) run shpec in multi_assert_example
-      # 2) remove shepec's final results section
-      # 3) remove all color escape chars
-      # 4) remove all ascii formating characters expect newlines (whitespace)
-      output="$(shpec $SHPEC_ROOT/etc/multi_assert_example |
-                    sed "5,\$d" |
-                    sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" |
-                    tr -d -c '\n[:print:]'
-               )"
+      output="$(. $SHPEC_ROOT/etc/multi_assert_example)"
 
-      expected="a assert"
-      expected="${expected}\nmulti assert" # which is present in the string but hidden in the terminal
-      expected="${expected}\n[1Amulti assert(x2)"
-      expected="${expected}\nanother assert"
-
-      assert equal "${output}" "${expected}"
+      assert match "$output" "a\ assert*multi\ assert*x[0-9]*another\ assert"
     end
 
-
     it "doesn't join FAILED identical assert names"
-        # see previous test
-        output="$(shpec $SHPEC_ROOT/etc/multi_assert_fail_example |
-                        sed "5,\$d" |
-                        sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" |
-                        tr -d -c '\n[:print:]'
-                )"
+        output="$(. $SHPEC_ROOT/etc/multi_assert_fail_example)"
 
-        expected="assert with errors"
-        expected="${expected}\nassert with errors"
-        expected="${expected}\n(Expected [1] to equal [2])"
-        expected="${expected}\nassert with errors"
-
-        assert equal "${output}" "${expected}"
+        assert match "$output" "assert\ with\ errors*assert\ with\ errors"
+        assert match "$output" "Expected\ \[1\]\ to\ equal\ \[2\]"
+        assert no_match "$output" "x[0-9]*"
     end
   end
 

--- a/shpec/shpec_shpec.sh
+++ b/shpec/shpec_shpec.sh
@@ -35,8 +35,7 @@ describe "shpec"
 
   describe "equality matcher"
     it "handles newlines properly"
-      string_with_newline_char="new
-line"
+      string_with_newline_char="new\nline"
       multiline_string='new
 line'
       assert equal "$multiline_string" "$string_with_newline_char"


### PR DESCRIPTION
This issue was mentioned in #105 and is [currently breaking master](https://travis-ci.org/rylnd/shpec/builds/217680295).

This is a quick fix to get master green; long-term I'd like to replace most of the existing uses of `match` in our suite with the matchers provided in #97. If there are legitimate use cases for `match` over `grep`, we don't currently have them documented.