### PR TITLE
"match" matcher doesn't support spaces in the right parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ match         # regex match
 no_match      # lack of regex match
 ```
 
+*Note:* for `match` and `no_match` matchers the righthand string should be escaped.
+
+Example:
+```
+  assert match "a = b" "a\ =\ b"  # Correct
+  assert match "a = b" "a = b"    # NOT correct
+```
+
 #### Unary Matchers
 ```bash
 present       # string presence


### PR DESCRIPTION
After I looked at the examples it seems to be a known and expected issue.

Hence I updated README with the notes about this behaviour which looks like a bug for new users.

If you think I should put that to a different section of a README please let me know and I'll fix it.