### PR TITLE
Override locale when checking a command's type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: sh
 cache: apt
 env:
-  matrix:
-    - LINT=true
-    - SHELL=bash
-    - SHELL=dash
-    - SHELL=ksh
-    - SHELL=zsh
+  - LINT=true
+  - SHELL=bash
+  - SHELL=dash
+  - SHELL=ksh
+  - SHELL=zsh
 matrix:
   include:
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - SHELL=dash
   - SHELL=ksh
   - SHELL=zsh
+  - SHELL=bash NON_ENGLISH=true LC_ALL=fr_FR.UTF-8
 matrix:
   fast_finish: true
   include:
@@ -38,12 +39,20 @@ before_install:
       sudo apt-get update -qq
       sudo apt-get install -y $SHELL
     }
+    install_language_pack() {
+      echo "Installing language pack"
+      sudo apt-get --reinstall install -qq language-pack-fr
+    }
 
     if [ "${SHELL}" = "zsh" ]; then
       echo "disable -r end; setopt sh_word_split" >> $HOME/.zshenv
     fi
 
     if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+      if [ -n "${NON_ENGLISH}" ]; then
+        install_language_pack
+      fi
+
       if [ -n "${LINT}" ]; then
         install_shellcheck 0.3.5-3 0.3.4-3
       elif ! type $SHELL > /dev/null; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,55 +7,45 @@ env:
   - SHELL=ksh
   - SHELL=zsh
 matrix:
-  include:
-    - os: osx
-      env: SHELL=bash
-  exclude:
-    - os: osx
   fast_finish: true
-os:
-  - linux
-  - osx
+  include:
+    - env:
+        - SHELL=bash
+      os: osx
 script:
   - |
-    $SHELL --version
-
-    if [ "$SHELL" = "zsh" ]; then
-      cat > $HOME/.zshenv <<END
-        disable -r end
-        setopt sh_word_split
-    END
-
-    fi
-    if ${LINT:-false}; then
+    if [ -n "${LINT}" ]; then
       shellcheck -s sh bin/shpec  # 'sh' refers to POSIX
     else
       $SHELL bin/shpec
     fi
 before_install:
   - |
-    if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-      get_shellcheck() {
-        (
-        for v
-        do
-          pkg=shellcheck_${v}_amd64.deb
-          url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
-          wget $url/$pkg || continue
-          echo $pkg
-          break
-        done
-        )
-      }
-      install_shell(){
-        echo "Install $SHELL"
-        sudo apt-get update -qq
-        sudo apt-get install -y $SHELL
-      }
-
-      if ${LINT:-false}; then
-        pkg=$( get_shellcheck 0.3.5-3 0.3.4-3 )
+    install_shellcheck() {
+      (
+      for v; do
+        pkg=shellcheck_${v}_amd64.deb
+        url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
+        wget $url/$pkg || continue
+        echo "Installing $pkg"
         sudo dpkg -i $pkg
+        break
+      done
+      )
+    }
+    install_shell() {
+      echo "Installing $SHELL"
+      sudo apt-get update -qq
+      sudo apt-get install -y $SHELL
+    }
+
+    if [ "${SHELL}" = "zsh" ]; then
+      echo "disable -r end; setopt sh_word_split" >> $HOME/.zshenv
+    fi
+
+    if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+      if [ -n "${LINT}" ]; then
+        install_shellcheck 0.3.5-3 0.3.4-3
       elif ! type $SHELL > /dev/null; then
         install_shell
       fi

--- a/bin/shpec
+++ b/bin/shpec
@@ -50,7 +50,7 @@ it() {
 }
 
 is_function() {
-  case $(type "$1" 2> /dev/null) in
+  case $(LC_ALL=C type "$1" 2> /dev/null) in
     (*function*) return 0;;
   esac
   return 1


### PR DESCRIPTION
Fixes #90 (yes, for the third time). All credit to @LeahCim and @eviweb for fixing it the first two times :wink:.

A few notes:

1. As opposed to stubbing `type` in a regression test, I opted to reproduce the error "in the wild" by adding a build for a non-english locale (see [this build](https://travis-ci.org/rylnd/shpec/builds/225485155)).
2. I am a simple man who has only his observations to guide him. I assume that the failure I've reproduced is in fact the problem as described in #90, and that, since the build is now green, the code on this branch addresses the issue. If I have missed some nuance of the problem, do let me know (or, of course, reopen the issue if you are still having problems).

Once this is merged, I will package a new release.