### PR TITLE
fix for `tar` not compiled with support for `gzip`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ TMPDIR=${TMPDIR:-/tmp}
 SHPECDIR=${TMPDIR}/shpec-${VERSION}
 
 cd $TMPDIR
-curl -sL https://github.com/rylnd/shpec/archive/${VERSION}.tar.gz | tar zxf -
+curl -sL https://github.com/rylnd/shpec/archive/${VERSION}.tar.gz | gunzip | tar xf -
 cd $SHPECDIR
 make install
 cd $TMPDIR


### PR DESCRIPTION
In case `tar` isn't compiled with support for `gzip` => `z` option is not available.

In my use case (with BusyBox) it fails with:

	+ VERSION=0.3.0
	+ TMPDIR=/tmp
	+ SHPECDIR=/tmp/shpec-0.3.0
	+ cd /tmp
	+ curl -sL https://github.com/rylnd/shpec/archive/0.3.0.tar.gz
	+ tar zxf -
	tar: invalid option -- 'z'
	BusyBox v1.22.1 (2014-05-23 01:24:27 UTC) multi-call binary.

	Usage: tar -[cxthvO] [-X FILE] [-T FILE] [-f TARFILE] [-C DIR] [FILE]...

	Create, extract, or list files from a tar file

	Operation:
		c       Create
		x       Extract
		t       List
		f       Name of TARFILE ('-' for stdin/out)
		C       Change to DIR before operation
		v       Verbose
		O       Extract to stdout
		h       Follow symlinks
		exclude File to exclude
		X       File with names to exclude
		T       File with names to include

So let's just use separate utility for `gzip` part.