### PR TITLE
Fixes shellcheck errors (and the build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,6 @@ script:
     fi
 before_install:
   - |
-    install_shellcheck() {
-      (
-      for v; do
-        pkg=shellcheck_${v}_amd64.deb
-        url="http://ftp.debian.org/debian/pool/main/s/shellcheck/"
-        wget $url/$pkg || continue
-        echo "Installing $pkg"
-        sudo dpkg -i $pkg
-        break
-      done
-      )
-    }
     install_shell() {
       echo "Installing $SHELL"
       sudo apt-get update -qq
@@ -53,9 +41,7 @@ before_install:
         install_language_pack
       fi
 
-      if [ -n "${LINT}" ]; then
-        install_shellcheck 0.3.5-3 0.3.4-3
-      elif ! type $SHELL > /dev/null; then
+      if ! type $SHELL > /dev/null; then
         install_shell
       fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 script:
   - |
     if [ -n "${LINT}" ]; then
+      shellcheck --version
       shellcheck -s sh bin/shpec  # 'sh' refers to POSIX
     else
       $SHELL bin/shpec

--- a/bin/shpec
+++ b/bin/shpec
@@ -50,7 +50,7 @@ it() {
 }
 
 is_function() {
-  case $(LC_ALL=C type "$1" 2> /dev/null) in
+  case $(LC_ALL=C command -V "$1" 2> /dev/null) in
     (*function*) return 0;;
   esac
   return 1
@@ -191,6 +191,7 @@ shpec() {
     )
 
     for _shpec_matcher_file in $_shpec_matcher_files; do
+      # shellcheck source=/dev/null
       . "$_shpec_matcher_file"
     done
 
@@ -203,6 +204,7 @@ shpec() {
     fi
 
     for _shpec_file in $_shpec_files; do
+      # shellcheck source=/dev/null
       . "$_shpec_file"
     done
 


### PR DESCRIPTION
* Tell shellcheck to ignore sourced test files
* uses `command -V` instead of `type`
  * This should be backwards-compatible with previous versions as `command` should be more portable than `type. This can be a patch release, I think.