### PR TITLE
Windows with git-bash execution fix

### DIFF
--- a/bin/shpec
+++ b/bin/shpec
@@ -213,10 +213,6 @@ shpec() {
 }
 
 (
-  _progname=shpec
-  _pathname=$( command -v "$0" )
-  _cmdname=${_pathname##*/}
   _main=shpec
-
-  case $_progname in (${_cmdname%.sh}) $_main "$@";; esac
+  $_main "$@"
 )


### PR DESCRIPTION
In windows environment (git-bash), the following command: `command -v "$0"` returns empty string. Therefor the `$_main` function is never called. So preventing any further checks, just calling the function with arguments. Not sure whether it could cause regressions to existing usages.